### PR TITLE
Implement -- get my team members API (manager role)

### DIFF
--- a/back_end/src/db/repositories/team_repository.ts
+++ b/back_end/src/db/repositories/team_repository.ts
@@ -72,9 +72,13 @@ export async function findTeamByUserId(userId: number,): Promise<{ teamId: numbe
   return result[0] ?? null;
 }
 
-export async function findAllTeams() {
+export async function findAllTeams(): Promise<{ id: number; name: string; managerId: number }[]> {
   const result = await db()
-    .select()
+    .select({
+      id: team.id,
+      name: team.name,
+      managerId: team.managerId,
+    })
     .from(team);
 
   return result;

--- a/back_end/src/db/repositories/team_repository.ts
+++ b/back_end/src/db/repositories/team_repository.ts
@@ -3,6 +3,7 @@ import { db } from "../db.client";
 import { team } from "../schema/team";
 import { eq } from "drizzle-orm";
 import { users } from "../schema/user";
+import { teamMember } from "../schema/team-member";
 
 export async function createTeam(input: CreateTeamInput): Promise<void> {
   const { name, managerId, userId } = input;
@@ -44,3 +45,21 @@ export const deleteTeam = async (id: number): Promise<number> => {
     .returning({id: team.id})
   return deleted.length;
 };
+
+export async function findUsersByTeamId(
+    teamId: number,
+): Promise<{ id: number; fullName: string; email: string; role: string }[]> {
+
+    const result = await db()
+        .select({
+            id: users.id,
+            fullName: users.fullName,
+            email: users.email,
+            role: users.role,
+        })
+        .from(teamMember)
+        .innerJoin(users, eq(teamMember.userId, users.id))
+        .where(eq(teamMember.teamId, teamId));
+
+    return result;
+}

--- a/back_end/src/db/repositories/team_repository.ts
+++ b/back_end/src/db/repositories/team_repository.ts
@@ -46,9 +46,7 @@ export const deleteTeam = async (id: number): Promise<number> => {
   return deleted.length;
 };
 
-export async function findUsersByTeamId(
-    teamId: number,
-): Promise<{ id: number; fullName: string; email: string; role: string }[]> {
+export async function findUsersByTeamId(teamId: number,): Promise<{ id: number; fullName: string; email: string; role: string }[]> {
 
     const result = await db()
         .select({
@@ -62,4 +60,36 @@ export async function findUsersByTeamId(
         .where(eq(teamMember.teamId, teamId));
 
     return result;
+}
+
+export async function findTeamByUserId(userId: number,): Promise<{ teamId: number } | null> {
+
+  const result = await db()
+    .select({teamId: teamMember.teamId,})
+    .from(teamMember)
+    .where(eq(teamMember.userId, userId));
+
+  return result[0] ?? null;
+}
+
+export async function findAllTeams() {
+  const result = await db()
+    .select()
+    .from(team);
+
+  return result;
+}
+
+export async function findTeamById(teamId: number,): Promise<{ id: number; name: string; managerId: number } | null> {
+
+  const result = await db()
+    .select({
+      id: team.id,
+      name: team.name,
+      managerId: team.managerId,
+    })
+    .from(team)
+    .where(eq(team.id, teamId));
+
+  return result[0] ?? null;
 }

--- a/back_end/src/routes/team.route.ts
+++ b/back_end/src/routes/team.route.ts
@@ -4,7 +4,9 @@ import { z } from "zod";
 import { role } from "../types/user.type";
 import { createTeamService } from "../services/teamService";
 import { deleteTeamById } from "../services/teamService";
-import { getMyTeamMembers } from "../services/teamService";
+import { getMyTeamMembersService } from "../services/teamService";
+import { getTeamDetailsService } from "../services/teamService";
+import { getAllTeamsService } from "../services/teamService";
 
 const router = Router();
 
@@ -54,46 +56,71 @@ router.post("/", authMiddleware(role.admin), async (req, res: Response) => {
   }
 });
 
-router.delete("/delete/:id", authMiddleware(role.admin), async (req, res: Response) => {
-  try {
-    const id = Number(req.params.id);
-    if (isNaN(id)) {
-      return res.status(400).json({ message: "Invalid team id" });
-    }
-    await deleteTeamById(id);
-    res.status(200).json({ message: "Team deleted successfully" });
-  } catch (error: any) {
-    res.status(404).json({ message: error.message });
+router.delete("/delete/:id", authMiddleware(role.admin), async (req, res: Response): Promise<void> => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(400).json({ message: "Invalid team id" });
+    return;
   }
-});
-
-router.get("/my-team-members",authMiddleware(role.manager),async (req, res: Response): Promise<void> => {
   try {
-    const members = await getMyTeamMembers(req.user.id);
-    res.status(200).json({data: members,});
-  } 
+    await deleteTeamById(id);
+    res.status(200).json({message: "Team deleted successfully",});
+  }
   catch (error: unknown) {
-    if (error instanceof Error) {
-      if (error.message === "User not found") {
-        res.status(404).json({message: "Manager not found.",});
-        return;
-      }
-
-      if (error.message === "Access denied") {
-        res.status(403).json({message: "You are not authorized to view team members.",});
-        return;
-      }
-
-      if (error.message === "Manager has no team") {
-        res.status(400).json({message: "No team assigned to this manager.",});
-        return;
-      }
-      
-      res.status(500).json({message: "Unexpected server error.",});
-      return;
-    }
+    const message = error instanceof Error? error.message: "Failed to delete team";
+    res.status(message === "Team not found" ? 404 : 500).json({message,});
   }
 },
 );
 
 export default router;
+
+router.get("/team-members",authMiddleware(),async (req, res: Response): Promise<void> => {
+  try {
+    const teamId = req.query.teamId? Number(req.query.teamId): undefined;
+    const result = await getMyTeamMembersService(
+      req.user.id,
+      teamId,
+    );
+    res.status(200).json({ data: result });
+  }
+  catch (error: unknown) {
+    res.status(400).json({
+      message:
+      error instanceof Error? error.message: "Failed to fetch team members",
+    });
+  }
+},
+);
+
+router.get("/team-details",authMiddleware(),async (req, res: Response): Promise<void> => {
+  try {
+    const teamId = req.query.teamId? Number(req.query.teamId): undefined;
+    const result = await getTeamDetailsService(
+      req.user.id,
+      teamId,
+    );
+    res.status(200).json({ data: result });
+  }
+  catch (error: unknown) {
+    res.status(400).json({
+      message:
+      error instanceof Error? error.message: "Failed to fetch team details",
+    });
+  }
+},
+);
+
+router.get("/all",authMiddleware(),async (req, res: Response): Promise<void> => {
+  try {
+    const result = await getAllTeamsService(req.user.id);
+    res.status(200).json({ data: result });
+  }
+  catch (error: unknown) {
+    res.status(403).json({
+      message:
+      error instanceof Error? error.message: "Access denied",
+    });
+  }
+},
+);

--- a/back_end/src/routes/team.route.ts
+++ b/back_end/src/routes/team.route.ts
@@ -15,6 +15,31 @@ const teamSchema = z.object({
   managerId: z.number(),
 });
 
+const teamMembersQuerySchema = z.object({
+  teamId: z
+    .string()
+    .optional()
+    .transform((val) => (val ? Number(val) : undefined))
+    .refine((val) => val === undefined || (Number.isInteger(val) && val > 0), {
+      message: "teamId must be a positive integer",
+    }),
+});
+
+const teamDetailsQuerySchema = z.object({
+  teamId: z
+    .string()
+    .optional()
+    .transform((val) => (val ? Number(val) : undefined))
+    .refine(
+      (val) =>
+        val === undefined ||
+        (Number.isInteger(val) && val > 0),
+      {
+        message: "teamId must be a positive integer",
+      }
+    ),
+});
+
 router.post("/", authMiddleware(role.admin), async (req, res: Response) => {
   try {
     const parsed = teamSchema.safeParse(req.body);
@@ -70,57 +95,94 @@ router.delete("/delete/:id", authMiddleware(role.admin), async (req, res: Respon
     const message = error instanceof Error? error.message: "Failed to delete team";
     res.status(message === "Team not found" ? 404 : 500).json({message,});
   }
-},
-);
+});
 
 router.get("/members",authMiddleware(),async (req, res: Response): Promise<void> => {
   try {
-    const teamId = req.query.teamId? Number(req.query.teamId): undefined;
-    const result = await getMyTeamMembersService(
-      req.user.id,
-      teamId,
-    );
+    const parsed = teamMembersQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({message: "Invalid query parameters",});
+      return;  
+    }
+    
+    const teamId = parsed.data.teamId;
+    const result = await getMyTeamMembersService(req.user.id,teamId);
     res.status(200).json({ data: result });
+
   }
   catch (error: unknown) {
-    res.status(400).json({
-      message:
-      error instanceof Error? error.message: "Failed to fetch team members",
-    });
+    if (error instanceof Error) {
+      if (error.message === "User not found") {
+        res.status(404).json({ message: error.message });
+        return;
+      }
+
+      if (error.message === "Access denied") {
+        res.status(403).json({ message: error.message });
+        return;
+      }
+      
+      res.status(400).json({ message: error.message });
+      return;
+    }
+    
+    res.status(500).json({message: "Internal server error",});
   }
-},
-);
+});
 
 router.get("/details",authMiddleware(),async (req, res: Response): Promise<void> => {
   try {
-    const teamId = req.query.teamId? Number(req.query.teamId): undefined;
+    const parsed = teamDetailsQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({message: "Invalid query parameters",});
+      return;
+    }
+
+    const teamId = parsed.data.teamId;
     const result = await getTeamDetailsService(
       req.user.id,
-      teamId,
+      teamId
     );
     res.status(200).json({ data: result });
   }
-  catch (error: unknown) {
-    res.status(400).json({
-      message:
-      error instanceof Error? error.message: "Failed to fetch team details",
-    });
-  }
-},
-);
 
-router.get("/all",authMiddleware(),async (req, res: Response): Promise<void> => {
+  catch (error: unknown) {
+    if (error instanceof Error) {
+      if (error.message === "User not found") {
+        res.status(404).json({ message: error.message });
+        return;
+      }
+      
+      if (error.message === "Access denied") {
+        res.status(403).json({ message: error.message });
+        return;
+      }
+      
+      if (error.message === "Team not found") {
+        res.status(404).json({ message: error.message });
+        return;
+      }
+
+      res.status(400).json({ message: error.message });
+      return;
+    }
+
+    res.status(500).json({message: "Internal server error",});
+  }
+});
+
+router.get("/all",authMiddleware(role.admin),async (req, res: Response): Promise<void> => {
   try {
     const result = await getAllTeamsService(req.user.id);
     res.status(200).json({ data: result });
   }
   catch (error: unknown) {
-    res.status(403).json({
-      message:
-      error instanceof Error? error.message: "Access denied",
-    });
+    if (error instanceof Error) {
+      res.status(500).json({message: error.message,});
+      return;
+    }
+    res.status(500).json({message: "Internal server error",});
   }
-},
-);
+});
 
 export default router;

--- a/back_end/src/routes/team.route.ts
+++ b/back_end/src/routes/team.route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { role } from "../types/user.type";
 import { createTeamService } from "../services/teamService";
 import { deleteTeamById } from "../services/teamService";
+import { getMyTeamMembers } from "../services/teamService";
 
 const router = Router();
 
@@ -65,5 +66,34 @@ router.delete("/delete/:id", authMiddleware(role.admin), async (req, res: Respon
     res.status(404).json({ message: error.message });
   }
 });
+
+router.get("/my-team-members",authMiddleware(role.manager),async (req, res: Response): Promise<void> => {
+  try {
+    const members = await getMyTeamMembers(req.user.id);
+    res.status(200).json({data: members,});
+  } 
+  catch (error: unknown) {
+    if (error instanceof Error) {
+      if (error.message === "User not found") {
+        res.status(404).json({message: "Manager not found.",});
+        return;
+      }
+
+      if (error.message === "Access denied") {
+        res.status(403).json({message: "You are not authorized to view team members.",});
+        return;
+      }
+
+      if (error.message === "Manager has no team") {
+        res.status(400).json({message: "No team assigned to this manager.",});
+        return;
+      }
+      
+      res.status(500).json({message: "Unexpected server error.",});
+      return;
+    }
+  }
+},
+);
 
 export default router;

--- a/back_end/src/routes/team.route.ts
+++ b/back_end/src/routes/team.route.ts
@@ -73,9 +73,7 @@ router.delete("/delete/:id", authMiddleware(role.admin), async (req, res: Respon
 },
 );
 
-export default router;
-
-router.get("/team-members",authMiddleware(),async (req, res: Response): Promise<void> => {
+router.get("/members",authMiddleware(),async (req, res: Response): Promise<void> => {
   try {
     const teamId = req.query.teamId? Number(req.query.teamId): undefined;
     const result = await getMyTeamMembersService(
@@ -93,7 +91,7 @@ router.get("/team-members",authMiddleware(),async (req, res: Response): Promise<
 },
 );
 
-router.get("/team-details",authMiddleware(),async (req, res: Response): Promise<void> => {
+router.get("/details",authMiddleware(),async (req, res: Response): Promise<void> => {
   try {
     const teamId = req.query.teamId? Number(req.query.teamId): undefined;
     const result = await getTeamDetailsService(
@@ -124,3 +122,5 @@ router.get("/all",authMiddleware(),async (req, res: Response): Promise<void> => 
   }
 },
 );
+
+export default router;

--- a/back_end/src/routes/user.route.ts
+++ b/back_end/src/routes/user.route.ts
@@ -16,7 +16,7 @@ router.get("/", authMiddleware(), (req: Request, res: Response) => {
 });
 
 const changeRoleSchema = z.object({
-  tragtedId: z.number(),
+  targtedId: z.number(),
   newRole: z.enum(["employee", "manager", "admin"]),
   platformSecret: z.string().optional(),
 });
@@ -24,7 +24,7 @@ const changeRoleSchema = z.object({
 router.patch("/",authMiddleware("admin"),async (req: Request, res: Response) => {
     try {
       const {
-        tragtedId: userId,
+        targtedId: userId,
         newRole,
         platformSecret,
       } = changeRoleSchema.parse(req.body);

--- a/back_end/src/services/teamService.ts
+++ b/back_end/src/services/teamService.ts
@@ -51,21 +51,36 @@ export async function getMyTeamMembersService(userId: number,requestedTeamId?: n
   const user = await findUserById(userId);
 
   if (!user) {throw new Error("User not found");}
-
+  
   if (user.role === role.admin) {
     if (!requestedTeamId) {throw new Error("Team id is required for admin");}
-    return await findUsersByTeamId(requestedTeamId);
+    
+    const team = await findTeamById(requestedTeamId);
+    if (!team) {throw new Error("Team not found");}
+    
+    const members = await findUsersByTeamId(requestedTeamId);
+    return {...team,members,};
   }
 
   if (user.role === role.manager) {
     const team = await findTeamByManagerId(userId);
     if (!team) {throw new Error("Manager has no team");}
-    return await findUsersByTeamId(team.id);
+    
+    const teamRef = await findTeamById(team.id);
+    if (!teamRef) {throw new Error("Team not found");}
+    
+    const members = await findUsersByTeamId(teamRef.id);
+    return {...teamRef,members};
   }
 
   const team = await findTeamByUserId(userId);
   if (!team) {throw new Error("User has no team");}
-  return await findUsersByTeamId(team.teamId);
+  
+  const teamRef = await findUserById(team.teamId);
+  if(!teamRef){ throw new Error("Team not found");}
+  
+  const members = await findUsersByTeamId(team.teamId)
+  return {...team,members};
 }
 
 export async function getTeamDetailsService(userId: number,requestedTeamId?: number,) {
@@ -86,9 +101,6 @@ export async function getTeamDetailsService(userId: number,requestedTeamId?: num
 }
 
 export async function getAllTeamsService(userId: number) {
-  const user = await findUserById(userId);
-  if (!user) {throw new Error("User not found");}
-  if (user.role !== role.admin) {throw new Error("Access denied");}
   return await findAllTeams();
 }
 

--- a/back_end/src/services/teamService.ts
+++ b/back_end/src/services/teamService.ts
@@ -6,6 +6,7 @@ import {
 } from "../db/repositories/team_repository";
 import { CreateTeamInput } from "src/types/team.type";
 import { deleteTeam} from "../db/repositories/team_repository";
+import { findUsersByTeamId } from "../db/repositories/team_repository";
 
 export async function createTeamService(input: CreateTeamInput) {
   const { name, managerId, userId } = input;
@@ -40,5 +41,30 @@ export async function deleteTeamById(id: number): Promise<void> {
   if (deletedCount === 0) {
     throw new Error("Team not found");
   }
+}
+
+export async function getMyTeamMembers(
+    managerId: number,
+): Promise<{ id: number; fullName: string; email: string; role: string }[]> {
+
+    const manager = await findUserById(managerId);
+
+    if (!manager) {
+        throw new Error("User not found");
+    }
+
+    if (manager.role !== "Manager") {
+        throw new Error("Access denied");
+    }
+
+    const team = await findTeamByManagerId(managerId);
+
+    if (!team) {
+        throw new Error("Manager has no team");
+    }
+
+    const members = await findUsersByTeamId(team.id);
+
+    return members;
 }
 

--- a/back_end/src/services/teamService.ts
+++ b/back_end/src/services/teamService.ts
@@ -7,6 +7,10 @@ import {
 import { CreateTeamInput } from "src/types/team.type";
 import { deleteTeam} from "../db/repositories/team_repository";
 import { findUsersByTeamId } from "../db/repositories/team_repository";
+import { role } from "../types/user.type";
+import { findTeamByUserId } from "../db/repositories/team_repository";
+import { findAllTeams } from "../db/repositories/team_repository";
+import { findTeamById } from "../db/repositories/team_repository";
 
 export async function createTeamService(input: CreateTeamInput) {
   const { name, managerId, userId } = input;
@@ -43,28 +47,48 @@ export async function deleteTeamById(id: number): Promise<void> {
   }
 }
 
-export async function getMyTeamMembers(
-    managerId: number,
-): Promise<{ id: number; fullName: string; email: string; role: string }[]> {
+export async function getMyTeamMembersService(userId: number,requestedTeamId?: number,) {
+  const user = await findUserById(userId);
 
-    const manager = await findUserById(managerId);
+  if (!user) {throw new Error("User not found");}
 
-    if (!manager) {
-        throw new Error("User not found");
-    }
+  if (user.role === role.admin) {
+    if (!requestedTeamId) {throw new Error("Team id is required for admin");}
+    return await findUsersByTeamId(requestedTeamId);
+  }
 
-    if (manager.role !== "Manager") {
-        throw new Error("Access denied");
-    }
+  if (user.role === role.manager) {
+    const team = await findTeamByManagerId(userId);
+    if (!team) {throw new Error("Manager has no team");}
+    return await findUsersByTeamId(team.id);
+  }
 
-    const team = await findTeamByManagerId(managerId);
+  const team = await findTeamByUserId(userId);
+  if (!team) {throw new Error("User has no team");}
+  return await findUsersByTeamId(team.teamId);
+}
 
-    if (!team) {
-        throw new Error("Manager has no team");
-    }
+export async function getTeamDetailsService(userId: number,requestedTeamId?: number,) {
+  const user = await findUserById(userId);
 
-    const members = await findUsersByTeamId(team.id);
+  if (!user) {throw new Error("User not found");}
+  
+  if (user.role === role.admin) {
+    if (!requestedTeamId) {throw new Error("Team id is required for admin");}
+    return await findTeamById(requestedTeamId);
+  }
+  
+  if (user.role === role.manager) {return await findTeamByManagerId(userId);}
 
-    return members;
+  const team = await findTeamByUserId(userId);
+  if (!team) {throw new Error("User has no team");}
+  return await findTeamById(team.teamId);
+}
+
+export async function getAllTeamsService(userId: number) {
+  const user = await findUserById(userId);
+  if (!user) {throw new Error("User not found");}
+  if (user.role !== role.admin) {throw new Error("Access denied");}
+  return await findAllTeams();
 }
 


### PR DESCRIPTION
Implemented the Get My Team Members feature.

- Added a repository function that performs a relational join between teamMembers and users tables to fetch all members of a team.

- Implemented a service function that:

> - Validates manager existence
> - Checks role authorization
> - Ensures the manager is assigned to a team
> - Retrieves team members using existing repository functions

- Protected the route using role-based middleware.
- Reused existing functions like findUserById and findTeamByManagerId to avoid duplication.

Changes Made:
- Added Zod validation for teamId query params in /members and /details
- Prevented silent NaN errors from Number() conversion
- Refined catch blocks to return proper HTTP status codes (400/403/404/500)
- Moved admin authorization checks to authMiddleware
- Removed unnecessary DB role checks in service layer
- Fixed response return types to comply with Promise<void>
- Ensured PLATFORM_SECRET enforcement via env config